### PR TITLE
Fix: file_exists fails if BibtexBibDir is url

### DIFF
--- a/bibtexref3.php
+++ b/bibtexref3.php
@@ -978,6 +978,9 @@ function GetEntry($bib, $ref)
     {
       ParseBibFile($bib);
       $bibtable = $BibEntries[$bib];
+      # exit if file still not found
+      if ($bibtable == false)
+        return false;
     }
     
     reset($bibtable);
@@ -1132,26 +1135,25 @@ function ParseBibFile($bib_file)
         if (!$BibtexBibDir)
             $BibtexBibDir = FmtPageName('$UploadDir$UploadPrefixFmt', $pagename);
     
-        if (file_exists($BibtexBibDir . $bib_file))
+        # try to open file
+        $f = fopen($BibtexBibDir . $bib_file, "r");
+        $bib_file_string = "";
+
+        if ($f)
         {
-            $f = fopen($BibtexBibDir . $bib_file, "r");
-            $bib_file_string = "";
-
-            if ($f)
+            while (!feof($f))
             {
-                while (!feof($f))
-                {
-                    $bib_file_string = $bib_file_string . fgets($f, 1024);
-                }
-
-                $bib_file_string = preg_replace("/\n/", "", $bib_file_string);
-
-                ParseBib($bib_file, $bib_file_string);
-
-                return true;
+                $bib_file_string = $bib_file_string . fgets($f, 1024);
             }
-            return false;
+
+            $bib_file_string = preg_replace("/\n/", "", $bib_file_string);
+
+            ParseBib($bib_file, $bib_file_string);
+
+            return true;
         }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
If BibtexBibDir is a url (which it is in my case), then file_exists(...) will report that the file does not exist.  However, attempting to open the file directly will work.

We recently tried upgrading from bibtexref2 to bibtexref3, and what originally worked now resulted in a lot of "invalid" entries.  With this change we restore the original functionality.